### PR TITLE
Fix function name typo inside a codition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,27 @@ To setup certbot initially, issue the following command.  This command will gene
 cloudflare-credentials /home/psiri/.cloudflare.ini -d *.bitbodyguard.com --preferred-challenges dns-01
 ```
 
+ # Initial Configuration - RFC 2136
+If your DNS server has RFC 2136 configured, you can use the rfc2136 variant of the script to generate certificates.
+  ```
+  sudo apt install certbot python3-certbot-dns-rfc2136
+  ```
+rfc2136.ini configuration example:
+```
+# Target DNS server (IPv4 or IPv6 address, not a hostname)
+dns_rfc2136_server = <YOUR_DNS_SERVER_IP>
+# Target DNS port
+dns_rfc2136_port = 53
+# TSIG key name
+dns_rfc2136_name = <KEY_NAME>
+# TSIG key secret
+dns_rfc2136_secret = <KEY_SECRET>
+# TSIG key algorithm
+dns_rfc2136_algorithm = HMAC-SHA512
+# TSIG sign SOA query (optional, default: false)
+dns_rfc2136_sign_query = false
+```
+
 # Initial Configuration - Standalone
 ### If you are not using CloudFlare DNS for authentication, you can optionally use the standalone method to perform initial certbot setup:
 

--- a/pan_certbot
+++ b/pan_certbot
@@ -69,7 +69,7 @@ elif [[ "$PACERT" == *'status="success" code="7"'* ]]; then
     if [ -e /etc/letsencrypt/live/$FQDN/cert.pem ]; then
         # If the local certificate for the FQDN exists but isn't present on Palo Alto, it will try to load the certificate
         echo "Certificate exists locally, uploading to Palo Alto."
-        UpdateCerts
+        UploadCerts
     else
         # If the certificate for FQDN doesn't exist both locally and in Palo Alto, it will try to renew and load the new certificate
         echo "Certificate for $FQDN not found! generating new certificate!"

--- a/pan_certbot
+++ b/pan_certbot
@@ -18,18 +18,63 @@ UploadCerts() {
     #Depending on your setup, certbot may not give you separate files for the certificate and chain.  This script expects separate files.
     sudo openssl pkcs12 -export -out letsencrypt_pkcs12.pfx -inkey /etc/letsencrypt/live/$FQDN/privkey.pem -in /etc/letsencrypt/live/$FQDN/cert.pem -certfile /etc/letsencrypt/live/$FQDN/cert.pem -passout pass:$TEMP_PWD
     if [ -e letsencrypt_pkcs12.pfx ]; then
+        echo "...Uploading certificate: $CERT_NAME"
         curl -k --form file=@letsencrypt_pkcs12.pfx "https://$PAN_MGMT/api/?type=import&category=certificate&certificate-name=$CERT_NAME&format=pkcs12&passphrase=$TEMP_PWD&key=$API_KEY" && echo " "
         curl -k --form file=@letsencrypt_pkcs12.pfx "https://$PAN_MGMT/api/?type=import&category=private-key&certificate-name=$CERT_NAME&format=pkcs12&passphrase=$TEMP_PWD&key=$API_KEY" && echo " "
         sudo rm letsencrypt_pkcs12.pfx
         #If you use a separate SSL/TLS Service Profile for the GlobalProtect Portal and Gateway, uncomment the next line and update the 'GP_PORTAL_TLS_PROFILE' variable with the name of your GlobalProtect Portal's SSL/TLS Service Profile, as it appears in your management GUI.
+        echo "...Changing SSL-TLS profiles"
         panxapi.py -h $PAN_MGMT -K $API_KEY -S "<certificate>$CERT_NAME</certificate>" "/config/shared/ssl-tls-service-profile/entry[@name='$GP_PORTAL_TLS_PROFILE']"
         #If you use a separate SSL/TLS Service Profile for the GlobalProtect Portal and Gateway, uncomment the next line and update the 'GP_GW_TLS_PROFILE' variable with the name of your GlobalProtect Gateway's SSL/TLS Service Profile, as it appears in your management GUI. If you use a single SSL/TLS Service Profile for BOTH the Portal and Gateway, you can comment the following line out, or set the value of 'GP_GW_TLS_PROFILE' to the value of 'GP_PORTAL_TLS_PROFILE'
         panxapi.py -h $PAN_MGMT -K $API_KEY -S "<certificate>$CERT_NAME</certificate>" "/config/shared/ssl-tls-service-profile/entry[@name='$GP_GW_TLS_PROFILE']"
+        echo "...Initiating commit"
         panxapi.py -h $PAN_MGMT -K $API_KEY -C '' --sync
     else
         echo "Error! .pfx file not found!"
     fi
 }
 
-GenCerts
-UploadCerts
+
+# Checks if CERT_NAME is present in Palo Alto
+PACERT=$(curl -k -G "https://$PAN_MGMT/api/" --data-urlencode "type=config" --data-urlencode "action=get" --data-urlencode "xpath=/config/shared/certificate/entry[@name='$CERT_NAME']" --data-urlencode "key=$API_KEY")
+
+if [[ "$PACERT" == *'status="success" code="19"'* ]]; then
+    # A certificate with CERT_NAME value is present, the code bellow will check if the expiry date matches with local certificate
+    PAEXPIRYDATE=$(echo $PACERT | awk -F'<not-valid-after[^>]*>|</not-valid-after>' '{print $2}')
+    echo "Palo Alto $CERT_NAME expiry date: $PAEXPIRYDATE"
+    if [ -e /etc/letsencrypt/live/$FQDN/cert.pem ]; then
+        # Extracts expiry date from local certificate and checks against PA
+        FILEEXPIRYDATE=$(openssl x509 -enddate -noout -in /etc/letsencrypt/live/$FQDN/cert.pem | awk -F'=' '{print $2}')
+        echo "File expiry date: $FILEEXPIRYDATE"
+        if [[ -n "$PAEXPIRYDATE" && -n "$FILEEXPIRYDATE" ]]; then
+            if [[ "$PAEXPIRYDATE" == "$FILEEXPIRYDATE" ]]; then
+               echo "Local certificate matches with Palo Alto certificate, nothing to do."
+            else
+                # If the expiry dates of both certificates don't match, it will try to renew and upload the new certificate
+                GenCerts
+                UploadCerts
+            fi
+        else
+            echo "Error: one of the expiry values is empty, please check your settings!"
+        fi
+    else
+        # If the local certificate for the FQDN doesn't exist, it will try to renew and load the new certificate
+        echo "Certificate for $FQDN not found, generating new certificate."
+        GenCerts
+        UploadCerts
+    fi
+elif [[ "$PACERT" == *'status="success" code="7"'* ]]; then
+    echo "Certificate with name $CERT_NAME is not present in Palo Alto"
+    if [ -e /etc/letsencrypt/live/$FQDN/cert.pem ]; then
+        # If the local certificate for the FQDN exists but isn't present on Palo Alto, it will try to load the certificate
+        echo "Certificate exists locally, uploading to Palo Alto."
+        UpdateCerts
+    else
+        # If the certificate for FQDN doesn't exist both locally and in Palo Alto, it will try to renew and load the new certificate
+        echo "Certificate for $FQDN not found! generating new certificate!"
+        GenCerts
+        UploadCerts
+    fi
+else
+    echo "API Error: $PACERT"
+fi

--- a/pan_certbot
+++ b/pan_certbot
@@ -17,14 +17,18 @@ GenCerts() {
 UploadCerts() {
     #Depending on your setup, certbot may not give you separate files for the certificate and chain.  This script expects separate files.
     sudo openssl pkcs12 -export -out letsencrypt_pkcs12.pfx -inkey /etc/letsencrypt/live/$FQDN/privkey.pem -in /etc/letsencrypt/live/$FQDN/cert.pem -certfile /etc/letsencrypt/live/$FQDN/cert.pem -passout pass:$TEMP_PWD
-    curl -k --form file=@letsencrypt_pkcs12.pfx "https://$PAN_MGMT/api/?type=import&category=certificate&certificate-name=$CERT_NAME&format=pkcs12&passphrase=$TEMP_PWD&key=$API_KEY" && echo " "
-    curl -k --form file=@letsencrypt_pkcs12.pfx "https://$PAN_MGMT/api/?type=import&category=private-key&certificate-name=$CERT_NAME&format=pkcs12&passphrase=$TEMP_PWD&key=$API_KEY" && echo " "
-    sudo rm letsencrypt_pkcs12.pfx
-    #If you use a separate SSL/TLS Service Profile for the GlobalProtect Portal and Gateway, uncomment the next line and update the 'GP_PORTAL_TLS_PROFILE' variable with the name of your GlobalProtect Portal's SSL/TLS Service Profile, as it appears in your management GUI.
-    panxapi.py -h $PAN_MGMT -K $API_KEY -S "<certificate>$CERT_NAME</certificate>" "/config/shared/ssl-tls-service-profile/entry[@name='$GP_PORTAL_TLS_PROFILE']"
-    #If you use a separate SSL/TLS Service Profile for the GlobalProtect Portal and Gateway, uncomment the next line and update the 'GP_GW_TLS_PROFILE' variable with the name of your GlobalProtect Gateway's SSL/TLS Service Profile, as it appears in your management GUI. If you use a single SSL/TLS Service Profile for BOTH the Portal and Gateway, you can comment the following line out, or set the value of 'GP_GW_TLS_PROFILE' to the value of 'GP_PORTAL_TLS_PROFILE'
-    panxapi.py -h $PAN_MGMT -K $API_KEY -S "<certificate>$CERT_NAME</certificate>" "/config/shared/ssl-tls-service-profile/entry[@name='$GP_GW_TLS_PROFILE']"
-    panxapi.py -h $PAN_MGMT -K $API_KEY -C '' --sync
+    if [ -e letsencrypt_pkcs12.pfx ]; then
+        curl -k --form file=@letsencrypt_pkcs12.pfx "https://$PAN_MGMT/api/?type=import&category=certificate&certificate-name=$CERT_NAME&format=pkcs12&passphrase=$TEMP_PWD&key=$API_KEY" && echo " "
+        curl -k --form file=@letsencrypt_pkcs12.pfx "https://$PAN_MGMT/api/?type=import&category=private-key&certificate-name=$CERT_NAME&format=pkcs12&passphrase=$TEMP_PWD&key=$API_KEY" && echo " "
+        sudo rm letsencrypt_pkcs12.pfx
+        #If you use a separate SSL/TLS Service Profile for the GlobalProtect Portal and Gateway, uncomment the next line and update the 'GP_PORTAL_TLS_PROFILE' variable with the name of your GlobalProtect Portal's SSL/TLS Service Profile, as it appears in your management GUI.
+        panxapi.py -h $PAN_MGMT -K $API_KEY -S "<certificate>$CERT_NAME</certificate>" "/config/shared/ssl-tls-service-profile/entry[@name='$GP_PORTAL_TLS_PROFILE']"
+        #If you use a separate SSL/TLS Service Profile for the GlobalProtect Portal and Gateway, uncomment the next line and update the 'GP_GW_TLS_PROFILE' variable with the name of your GlobalProtect Gateway's SSL/TLS Service Profile, as it appears in your management GUI. If you use a single SSL/TLS Service Profile for BOTH the Portal and Gateway, you can comment the following line out, or set the value of 'GP_GW_TLS_PROFILE' to the value of 'GP_PORTAL_TLS_PROFILE'
+        panxapi.py -h $PAN_MGMT -K $API_KEY -S "<certificate>$CERT_NAME</certificate>" "/config/shared/ssl-tls-service-profile/entry[@name='$GP_GW_TLS_PROFILE']"
+        panxapi.py -h $PAN_MGMT -K $API_KEY -C '' --sync
+    else
+        echo "Error! .pfx file not found!"
+    fi
 }
 
 GenCerts

--- a/pan_certbot
+++ b/pan_certbot
@@ -11,7 +11,7 @@ TEMP_PWD=$(openssl rand -hex 15)
 #Requirements: openssl, pan-python, certbot
 
 GenCerts() {
-    sudo /usr/local/bin/certbot certonly --dns-cloudflare --dns-cloudflare-credentials $CLOUDFLARE_CREDS -d *.$FQDN -n --agree-tos
+    sudo /usr/local/bin/certbot certonly --dns-cloudflare --dns-cloudflare-credentials $CLOUDFLARE_CREDS -d *.$FQDN -n --agree-tos --no-eff-email --quiet
 }
 
 UploadCerts() {

--- a/pan_certbot
+++ b/pan_certbot
@@ -10,14 +10,22 @@ GP_GW_TLS_PROFILE=GP_EXT_GW_PROFILE
 TEMP_PWD=$(openssl rand -hex 15)
 #Requirements: openssl, pan-python, certbot
 
-sudo /usr/local/bin/certbot certonly --dns-cloudflare --dns-cloudflare-credentials $CLOUDFLARE_CREDS -d *.$FQDN -n --agree-tos --force-renew
-#Depending on your setup, certbot may not give you separate files for the certificate and chain.  This script expects separate files.
-sudo openssl pkcs12 -export -out letsencrypt_pkcs12.pfx -inkey /etc/letsencrypt/live/$FQDN/privkey.pem -in /etc/letsencrypt/live/$FQDN/cert.pem -certfile /etc/letsencrypt/live/$FQDN/cert.pem -passout pass:$TEMP_PWD
-curl -k --form file=@letsencrypt_pkcs12.pfx "https://$PAN_MGMT/api/?type=import&category=certificate&certificate-name=$CERT_NAME&format=pkcs12&passphrase=$TEMP_PWD&key=$API_KEY" && echo " "
-curl -k --form file=@letsencrypt_pkcs12.pfx "https://$PAN_MGMT/api/?type=import&category=private-key&certificate-name=$CERT_NAME&format=pkcs12&passphrase=$TEMP_PWD&key=$API_KEY" && echo " "
-sudo rm letsencrypt_pkcs12.pfx
-#If you use a separate SSL/TLS Service Profile for the GlobalProtect Portal and Gateway, uncomment the next line and update the 'GP_PORTAL_TLS_PROFILE' variable with the name of your GlobalProtect Portal's SSL/TLS Service Profile, as it appears in your management GUI.
-panxapi.py -h $PAN_MGMT -K $API_KEY -S "<certificate>$CERT_NAME</certificate>" "/config/shared/ssl-tls-service-profile/entry[@name='$GP_PORTAL_TLS_PROFILE']"
-#If you use a separate SSL/TLS Service Profile for the GlobalProtect Portal and Gateway, uncomment the next line and update the 'GP_GW_TLS_PROFILE' variable with the name of your GlobalProtect Gateway's SSL/TLS Service Profile, as it appears in your management GUI. If you use a single SSL/TLS Service Profile for BOTH the Portal and Gateway, you can comment the following line out, or set the value of 'GP_GW_TLS_PROFILE' to the value of 'GP_PORTAL_TLS_PROFILE'
-panxapi.py -h $PAN_MGMT -K $API_KEY -S "<certificate>$CERT_NAME</certificate>" "/config/shared/ssl-tls-service-profile/entry[@name='$GP_GW_TLS_PROFILE']"
-panxapi.py -h $PAN_MGMT -K $API_KEY -C '' --sync
+GenCerts() {
+    sudo /usr/local/bin/certbot certonly --dns-cloudflare --dns-cloudflare-credentials $CLOUDFLARE_CREDS -d *.$FQDN -n --agree-tos --force-renew
+}
+
+UploadCerts() {
+    #Depending on your setup, certbot may not give you separate files for the certificate and chain.  This script expects separate files.
+    sudo openssl pkcs12 -export -out letsencrypt_pkcs12.pfx -inkey /etc/letsencrypt/live/$FQDN/privkey.pem -in /etc/letsencrypt/live/$FQDN/cert.pem -certfile /etc/letsencrypt/live/$FQDN/cert.pem -passout pass:$TEMP_PWD
+    curl -k --form file=@letsencrypt_pkcs12.pfx "https://$PAN_MGMT/api/?type=import&category=certificate&certificate-name=$CERT_NAME&format=pkcs12&passphrase=$TEMP_PWD&key=$API_KEY" && echo " "
+    curl -k --form file=@letsencrypt_pkcs12.pfx "https://$PAN_MGMT/api/?type=import&category=private-key&certificate-name=$CERT_NAME&format=pkcs12&passphrase=$TEMP_PWD&key=$API_KEY" && echo " "
+    sudo rm letsencrypt_pkcs12.pfx
+    #If you use a separate SSL/TLS Service Profile for the GlobalProtect Portal and Gateway, uncomment the next line and update the 'GP_PORTAL_TLS_PROFILE' variable with the name of your GlobalProtect Portal's SSL/TLS Service Profile, as it appears in your management GUI.
+    panxapi.py -h $PAN_MGMT -K $API_KEY -S "<certificate>$CERT_NAME</certificate>" "/config/shared/ssl-tls-service-profile/entry[@name='$GP_PORTAL_TLS_PROFILE']"
+    #If you use a separate SSL/TLS Service Profile for the GlobalProtect Portal and Gateway, uncomment the next line and update the 'GP_GW_TLS_PROFILE' variable with the name of your GlobalProtect Gateway's SSL/TLS Service Profile, as it appears in your management GUI. If you use a single SSL/TLS Service Profile for BOTH the Portal and Gateway, you can comment the following line out, or set the value of 'GP_GW_TLS_PROFILE' to the value of 'GP_PORTAL_TLS_PROFILE'
+    panxapi.py -h $PAN_MGMT -K $API_KEY -S "<certificate>$CERT_NAME</certificate>" "/config/shared/ssl-tls-service-profile/entry[@name='$GP_GW_TLS_PROFILE']"
+    panxapi.py -h $PAN_MGMT -K $API_KEY -C '' --sync
+}
+
+GenCerts
+UploadCerts

--- a/pan_certbot
+++ b/pan_certbot
@@ -11,7 +11,7 @@ TEMP_PWD=$(openssl rand -hex 15)
 #Requirements: openssl, pan-python, certbot
 
 GenCerts() {
-    sudo /usr/local/bin/certbot certonly --dns-cloudflare --dns-cloudflare-credentials $CLOUDFLARE_CREDS -d *.$FQDN -n --agree-tos --force-renew
+    sudo /usr/local/bin/certbot certonly --dns-cloudflare --dns-cloudflare-credentials $CLOUDFLARE_CREDS -d *.$FQDN -n --agree-tos
 }
 
 UploadCerts() {

--- a/pan_certbot
+++ b/pan_certbot
@@ -34,6 +34,8 @@ UploadCerts() {
     fi
 }
 
+# Initial attempt to renew the certificate
+GenCerts
 
 # Checks if CERT_NAME is present in Palo Alto
 PACERT=$(curl -k -G "https://$PAN_MGMT/api/" --data-urlencode "type=config" --data-urlencode "action=get" --data-urlencode "xpath=/config/shared/certificate/entry[@name='$CERT_NAME']" --data-urlencode "key=$API_KEY")
@@ -50,8 +52,7 @@ if [[ "$PACERT" == *'status="success" code="19"'* ]]; then
             if [[ "$PAEXPIRYDATE" == "$FILEEXPIRYDATE" ]]; then
                echo "Local certificate matches with Palo Alto certificate, nothing to do."
             else
-                # If the expiry dates of both certificates don't match, it will try to renew and upload the new certificate
-                GenCerts
+                # If the expiry date of both certificates don't match, it will try to upload the new certificate
                 UploadCerts
             fi
         else

--- a/pan_certbot_rfc2136
+++ b/pan_certbot_rfc2136
@@ -69,7 +69,7 @@ elif [[ "$PACERT" == *'status="success" code="7"'* ]]; then
     if [ -e /etc/letsencrypt/live/$FQDN/cert.pem ]; then
         # If the local certificate for the FQDN exists but isn't present on Palo Alto, it will try to load the certificate
         echo "Certificate exists locally, uploading to Palo Alto."
-        UpdateCerts
+        UploadCerts
     else
         # If the certificate for FQDN doesn't exist both locally and in Palo Alto, it will try to renew and load the new certificate
         echo "Certificate for $FQDN not found! generating new certificate!"

--- a/pan_certbot_rfc2136
+++ b/pan_certbot_rfc2136
@@ -1,0 +1,79 @@
+#!/bin/bash
+RFC2136FILE=<FULL_PATH_TO>/rfc2136.ini
+PAN_MGMT=<FW_MGMT_FQDN_OR_IP>
+FQDN=<CERTIFICATE_FQDN(s)>
+EMAIL=<EMAIL_ADDRESS>
+API_KEY=$(cat FULL_PATH_TO/.panrc)
+CERT_NAME=LetsEncryptWildcard
+GP_PORTAL_TLS_PROFILE=GP_PORTAL_PROFILE
+GP_GW_TLS_PROFILE=GP_EXT_GW_PROFILE
+TEMP_PWD=$(openssl rand -hex 15)
+#Requirements: openssl, pan-python, certbot
+
+GenCerts() {
+    sudo /usr/local/bin/certbot certonly --dns-rfc2136 --dns-rfc2136-credentials $RFC2136FILE -d *.$FQDN --email $EMAIL --agree-tos --no-eff-email --quiet
+}
+
+UploadCerts() {
+    #Depending on your setup, certbot may not give you separate files for the certificate and chain.  This script expects separate files.
+    sudo openssl pkcs12 -export -out letsencrypt_pkcs12.pfx -inkey /etc/letsencrypt/live/$FQDN/privkey.pem -in /etc/letsencrypt/live/$FQDN/cert.pem -certfile /etc/letsencrypt/live/$FQDN/cert.pem -passout pass:$TEMP_PWD
+    if [ -e letsencrypt_pkcs12.pfx ]; then
+        echo "...Uploading certificate: $CERT_NAME"
+        curl -k --form file=@letsencrypt_pkcs12.pfx "https://$PAN_MGMT/api/?type=import&category=certificate&certificate-name=$CERT_NAME&format=pkcs12&passphrase=$TEMP_PWD&key=$API_KEY" && echo " "
+        curl -k --form file=@letsencrypt_pkcs12.pfx "https://$PAN_MGMT/api/?type=import&category=private-key&certificate-name=$CERT_NAME&format=pkcs12&passphrase=$TEMP_PWD&key=$API_KEY" && echo " "
+        sudo rm letsencrypt_pkcs12.pfx
+        #If you use a separate SSL/TLS Service Profile for the GlobalProtect Portal and Gateway, uncomment the next line and update the 'GP_PORTAL_TLS_PROFILE' variable with the name of your GlobalProtect Portal's SSL/TLS Service Profile, as it appears in your management GUI.
+        echo "...Changing SSL-TLS profiles"
+        panxapi.py -h $PAN_MGMT -K $API_KEY -S "<certificate>$CERT_NAME</certificate>" "/config/shared/ssl-tls-service-profile/entry[@name='$GP_PORTAL_TLS_PROFILE']"
+        #If you use a separate SSL/TLS Service Profile for the GlobalProtect Portal and Gateway, uncomment the next line and update the 'GP_GW_TLS_PROFILE' variable with the name of your GlobalProtect Gateway's SSL/TLS Service Profile, as it appears in your management GUI. If you use a single SSL/TLS Service Profile for BOTH the Portal and Gateway, you can comment the following line out, or set the value of 'GP_GW_TLS_PROFILE' to the value of 'GP_PORTAL_TLS_PROFILE'
+        panxapi.py -h $PAN_MGMT -K $API_KEY -S "<certificate>$CERT_NAME</certificate>" "/config/shared/ssl-tls-service-profile/entry[@name='$GP_GW_TLS_PROFILE']"
+        echo "...Initiating commit"
+        panxapi.py -h $PAN_MGMT -K $API_KEY -C '' --sync
+    else
+        echo "Error! .pfx file not found!"
+    fi
+}
+
+# Checks if CERT_NAME is present in Palo Alto
+PACERT=$(curl -k -G "https://$PAN_MGMT/api/" --data-urlencode "type=config" --data-urlencode "action=get" --data-urlencode "xpath=/config/shared/certificate/entry[@name='$CERT_NAME']" --data-urlencode "key=$API_KEY")
+
+if [[ "$PACERT" == *'status="success" code="19"'* ]]; then
+    # A certificate with CERT_NAME value is present, the code bellow will check if the expiry date matches with local certificate
+    PAEXPIRYDATE=$(echo $PACERT | awk -F'<not-valid-after[^>]*>|</not-valid-after>' '{print $2}')
+    echo "Palo Alto $CERT_NAME expiry date: $PAEXPIRYDATE"
+    if [ -e /etc/letsencrypt/live/$FQDN/cert.pem ]; then
+        # Extracts expiry date from local certificate and checks against PA
+        FILEEXPIRYDATE=$(openssl x509 -enddate -noout -in /etc/letsencrypt/live/$FQDN/cert.pem | awk -F'=' '{print $2}')
+        echo "File expiry date: $FILEEXPIRYDATE"
+        if [[ -n "$PAEXPIRYDATE" && -n "$FILEEXPIRYDATE" ]]; then
+            if [[ "$PAEXPIRYDATE" == "$FILEEXPIRYDATE" ]]; then
+               echo "Local certificate matches with Palo Alto certificate, nothing to do."
+            else
+                # If the expiry dates of both certificates don't match, it will try to renew and upload the new certificate
+                GenCerts
+                UploadCerts
+            fi
+        else
+            echo "Error: one of the expiry values strings is empty, please check your settings!"
+        fi
+    else
+        # If the local certificate for the FQDN doesn't exist, it will try to renew and load the new certificate
+        echo "Certificate for $FQDN not found, generating new certificate."
+        GenCerts
+        UploadCerts
+    fi
+elif [[ "$PACERT" == *'status="success" code="7"'* ]]; then
+    echo "Certificate with name $CERT_NAME is not present in Palo Alto"
+    if [ -e /etc/letsencrypt/live/$FQDN/cert.pem ]; then
+        # If the local certificate for the FQDN exists but isn't present on Palo Alto, it will try to load the certificate
+        echo "Certificate exists locally, uploading to Palo Alto."
+        UpdateCerts
+    else
+        # If the certificate for FQDN doesn't exist both locally and in Palo Alto, it will try to renew and load the new certificate
+        echo "Certificate for $FQDN not found! generating new certificate!"
+        GenCerts
+        UploadCerts
+    fi
+else
+    echo "API Error: $PACERT"
+fi

--- a/pan_certbot_rfc2136
+++ b/pan_certbot_rfc2136
@@ -34,6 +34,9 @@ UploadCerts() {
     fi
 }
 
+# Initial attempt to renew the certificate
+GenCerts
+
 # Checks if CERT_NAME is present in Palo Alto
 PACERT=$(curl -k -G "https://$PAN_MGMT/api/" --data-urlencode "type=config" --data-urlencode "action=get" --data-urlencode "xpath=/config/shared/certificate/entry[@name='$CERT_NAME']" --data-urlencode "key=$API_KEY")
 
@@ -49,12 +52,11 @@ if [[ "$PACERT" == *'status="success" code="19"'* ]]; then
             if [[ "$PAEXPIRYDATE" == "$FILEEXPIRYDATE" ]]; then
                echo "Local certificate matches with Palo Alto certificate, nothing to do."
             else
-                # If the expiry dates of both certificates don't match, it will try to renew and upload the new certificate
-                GenCerts
+                # If the expiry date of both certificates don't match, it will try to upload the new certificate
                 UploadCerts
             fi
         else
-            echo "Error: one of the expiry values strings is empty, please check your settings!"
+            echo "Error: one of the expiry values is empty, please check your settings!"
         fi
     else
         # If the local certificate for the FQDN doesn't exist, it will try to renew and load the new certificate


### PR DESCRIPTION
This fixes a typo inside one of the conditions, its a rare condition so I don't think anyone was affected.